### PR TITLE
Update lockdown-browsers-autofill-and-password-manager.ps1

### DIFF
--- a/tasks/lockdown-browsers-autofill-and-password-manager.ps1
+++ b/tasks/lockdown-browsers-autofill-and-password-manager.ps1
@@ -142,6 +142,8 @@ param (
 
 if ($Browser -eq 'All') {
     $Browser = @('Chrome', 'Edge', 'Brave', 'Firefox')
+} else {
+   $Browser = $Browser
 }
 
 # Set Parameter to Variables


### PR DESCRIPTION
- It would not have worked for the `$Browser` not set to `All`. Because `$using:VariableName` inside the `Invoke-ImmyCommand ScriptBlock {}` does not accept parameters.