### PR TITLE
Senteon Agent

### DIFF
--- a/software/senteon-agent-dynamic-version.ps1
+++ b/software/senteon-agent-dynamic-version.ps1
@@ -1,6 +1,0 @@
-$URL = 'https://update.senteon.co/installers/SenteonAgent.msi'
-$Result = Get-DynamicVersionFromInstallerURL $URL
-$Response = New-Object PSObject -Property @{
-    Versions = @(New-DynamicVersion -URL $URL -Version $Result.Versions.Version)
-}
-return $Response

--- a/software/senteon-agent.toml
+++ b/software/senteon-agent.toml
@@ -81,8 +81,3 @@ Description = {}
 Test = "Disabled"
 Get = "Disabled"
 Set = "Disabled"
-
-[AdvancedSettings]
-[AdvancedSettings.DynamicVersions]
-"Use dynamic versions" = true
-"Dynamic Version Script" = "Senteon Agent Dynamic Versions Script" # Use the Get-SenteonAgentDynamicVersion.ps1 script


### PR DESCRIPTION
- Download Url is not returning content-deposition anymore and installing Version 1.0.0.0.
- Dynamic Versioning is not possible with this application 
- This [Url](https://senteon.readthedocs.io/en/latest/changelog_core/) returns `2.5.0.1` but the installer installs 1.0.0.0
- Installer: https://update.senteon.co/installers/SenteonAgent.msi